### PR TITLE
HMAN-489: Clean up hmc-operational-reports-runner suppressions

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -9,7 +9,7 @@ plugins {
   id 'org.owasp.dependencycheck' version '6.5.3'
   id 'org.sonarqube' version '3.3'
   id 'org.springframework.boot' version '2.7.3'
-  id 'uk.gov.hmcts.java' version '0.12.27'
+  id 'uk.gov.hmcts.java' version '0.12.34'
 }
 
 group = 'uk.gov.hmcts.reform'
@@ -135,7 +135,7 @@ def versions = [
         junitPlatform   : '1.7.2',
         lombok          : '1.18.20',
         reformLogging   : '5.1.9',
-        jackson         : '2.13.3',
+        jackson         : '2.14.0-rc1',
         springBoot      : springBoot.class.package.implementationVersion,
         springFramework : '5.3.20',
         springCloud     : '2020.0.1',
@@ -166,15 +166,6 @@ dependencyCheck {
     // Disable scanning of .NET related binaries
     assemblyEnabled = false
   }
-  skipConfigurations = [
-    "checkstyle",
-    "compileOnly",
-    "integrationTest",
-    "functionalTest",
-    "smokeTest",
-    "contractTestRuntimeClasspath",
-    "contractTestCompileClasspath"
-  ]
 }
 
 repositories {
@@ -191,8 +182,11 @@ ext {
 }
 
 dependencies {
+  implementation group: 'org.yaml', name: 'snakeyaml', version: '1.33'
+  implementation group: 'org.apache.tomcat.embed', name: 'tomcat-embed-core', version: '9.0.68'
+  implementation group: 'org.apache.tomcat.embed', name: 'tomcat-embed-websocket', version: '9.0.68'
 
-  implementation group: 'commons-io', name: 'commons-io', version: '2.6'
+  implementation group: 'commons-io', name: 'commons-io', version: '2.11.0'
 
   implementation group: 'javax.inject', name: 'javax.inject', version: '1'
   implementation 'com.fasterxml.jackson.dataformat:jackson-dataformat-csv:2.13.4'
@@ -227,7 +221,7 @@ dependencies {
   implementation group: 'io.rest-assured', name: 'rest-assured'
 
   implementation group: 'org.hibernate', name: 'hibernate-core', version: '5.5.7.Final'
-  runtimeOnly group: 'org.postgresql', name: 'postgresql', version: '42.4.2'
+  runtimeOnly group: 'org.postgresql', name: 'postgresql', version: '42.5.1'
 
   annotationProcessor group: 'org.projectlombok', name: 'lombok', version: versions.lombok
   testAnnotationProcessor group: 'org.projectlombok', name: 'lombok', version: versions.lombok

--- a/build.gradle
+++ b/build.gradle
@@ -135,7 +135,7 @@ def versions = [
         junitPlatform   : '1.7.2',
         lombok          : '1.18.20',
         reformLogging   : '5.1.9',
-        jackson         : '2.14.0-rc1',
+        jackson         : '2.14.1',
         springBoot      : springBoot.class.package.implementationVersion,
         springFramework : '5.3.20',
         springCloud     : '2020.0.1',

--- a/charts/hmc-operational-reports-runner/Chart.yaml
+++ b/charts/hmc-operational-reports-runner/Chart.yaml
@@ -8,5 +8,5 @@ maintainers:
   - name: HMCTS hmc team
 dependencies:
   - name: job
-    version: ~0.7.4
+    version: ~0.7.5
     repository: 'https://hmctspublic.azurecr.io/helm/v1/repo/'

--- a/charts/hmc-operational-reports-runner/Chart.yaml
+++ b/charts/hmc-operational-reports-runner/Chart.yaml
@@ -8,5 +8,5 @@ maintainers:
   - name: HMCTS hmc team
 dependencies:
   - name: job
-    version: ~0.7.3
+    version: ~0.7.4
     repository: 'https://hmctspublic.azurecr.io/helm/v1/repo/'

--- a/charts/hmc-operational-reports-runner/values.yaml
+++ b/charts/hmc-operational-reports-runner/values.yaml
@@ -41,3 +41,4 @@ job:
   global:
     jobKind: CronJob
     enableKeyVaults: true
+    environment: aat

--- a/charts/hmc-operational-reports-runner/values.yaml
+++ b/charts/hmc-operational-reports-runner/values.yaml
@@ -36,7 +36,7 @@ job:
           alias: CFT_HEARING_SERVICE_DB_PORT
         - name: cft-hearing-service-POSTGRES-DATABASE
           alias: CFT_HEARING_SERVICE_DB_NAME
-  environment:
+  #environment:
   #    TODO
   global:
     jobKind: CronJob

--- a/charts/hmc-operational-reports-runner/values.yaml
+++ b/charts/hmc-operational-reports-runner/values.yaml
@@ -36,7 +36,7 @@ job:
           alias: CFT_HEARING_SERVICE_DB_PORT
         - name: cft-hearing-service-POSTGRES-DATABASE
           alias: CFT_HEARING_SERVICE_DB_NAME
-  #environment:
+  environment:
   #    TODO
   global:
     jobKind: CronJob

--- a/config/owasp/suppressions.xml
+++ b/config/owasp/suppressions.xml
@@ -1,26 +1,17 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <suppressions xmlns="https://jeremylong.github.io/DependencyCheck/dependency-suppression.1.3.xsd">
-  <suppress until="2030-01-01">
-    <notes><![CDATA[
-     Suppressing as it's a false positive (see: https://pivotal.io/security/cve-2018-1258)
-   ]]></notes>
-    <gav regex="true">^org\.springframework\.security:spring-security-crypto:5.4.[0-5]</gav>
-    <cpe>cpe:/a:pivotal_software:spring_security</cpe>
-    <cve>CVE-2018-1258</cve>
-  </suppress>
+
+  <!--Please add all the false positives under the below section-->
+
+  <!--End of false positives section -->
+
+  <!--Please add all the temporary suppression under the below section-->
   <suppress>
-    <notes><![CDATA[
-        CVE is a json vulnerability for Node projects. False positive reported at https://github.com/jeremylong/DependencyCheck/issues/2794
-    ]]></notes>
-    <cve>CVE-2020-10663</cve>
-    <cve>CVE-2020-7712</cve>
-   </suppress>
-   <suppress until="2022-11-01">
-    <cve>CVE-2016-1000027</cve>
-     <cve>CVE-2022-25857</cve>
-     <cve>CVE-2021-29425</cve>
-     <cve>CVE-2022-38749</cve>
-     <cve>CVE-2022-38751</cve>
-     <cve>CVE-2022-38750</cve>
-   </suppress>
+    <notes>Temporary Suppression
+      CVE-2021-37533 refer https://tools.hmcts.net/jira/browse/CCD-4086
+    </notes>
+    <cve>CVE-2021-37533</cve>
+  </suppress>
+  <!--End of temporary suppression section -->
+
 </suppressions>


### PR DESCRIPTION
### JIRA link ###
https://tools.hmcts.net/jira/browse/HMAN-489

### Change description ###
Cleaned up hmc-operational-reports-runner suppressions.
Added default global.environment to resolve helm lint issue as per https://github.com/hmcts/wa-message-cron-service/blob/master/charts/wa-message-cron-service/values.yaml

**Does this PR introduce a breaking change?**
```
[ ] Yes
[x] No
```