### PR TITLE
HMAN-524 Upgrade dependencies to resolve CVE-2023-24998

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -173,9 +173,10 @@ ext {
 dependencies {
   implementation group: 'org.yaml', name: 'snakeyaml', version: '1.33'
 
-  implementation group: 'org.apache.tomcat.embed', name: 'tomcat-embed-core', version: '9.0.71'
-  implementation group: 'org.apache.tomcat.embed', name: 'tomcat-embed-websocket', version: '9.0.71'
+  implementation group: 'org.apache.tomcat.embed', name: 'tomcat-embed-core', version: '9.0.73'
+  implementation group: 'org.apache.tomcat.embed', name: 'tomcat-embed-websocket', version: '9.0.73'
 
+  implementation group: 'commons-fileupload', name: 'commons-fileupload', version: '1.5'
   implementation group: 'commons-io', name: 'commons-io', version: '2.11.0'
 
   implementation group: 'javax.inject', name: 'javax.inject', version: '1'


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/HMAN-524


### Change description ###
Upgrade tomcat and commons-fileupload  to resolve CVE-2023-24998

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ x] No
```
