### PR TITLE
HMAN-1133: Set Spring commons-lang3.version property

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -167,6 +167,7 @@ ext {
   set('log4j2.version', '2.25.3')
   set('jackson.version', '2.18.2')
   set('snakeyaml.version', '2.3')
+  set('commons-lang3.version', '3.18.0')
   reformLogging = '8.0.0'
   lombokVersion = '1.18.38'
   junit = '5.13.4'


### PR DESCRIPTION
### JIRA link (if applicable) ###
[HMAN-1133](https://tools.hmcts.net/jira/browse/HMAN-1133)


### Change description ###
Added Spring commons-lang3.version property to build.gradle and set value to 3.18.0.  This ensures that at least version 3.18.0 of apache commons-lang3 is used by dependencies.


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
