### PR TITLE
HMAN-1133: Update HMCTS Java and DependencyCheck plugins

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -5,10 +5,10 @@ plugins {
   id 'jacoco'
   id 'com.github.ben-manes.versions' version '0.52.0'
   id 'io.spring.dependency-management' version '1.1.7'
-  id 'org.owasp.dependencycheck' version '12.1.3'
+  id 'org.owasp.dependencycheck' version '12.2.1'
   id 'org.sonarqube' version '6.2.0.5505'
   id 'org.springframework.boot' version '3.5.4'
-  id 'uk.gov.hmcts.java' version '0.12.67'
+  id 'uk.gov.hmcts.java' version '0.12.70'
 }
 
 group = 'uk.gov.hmcts.reform'

--- a/config/owasp/suppressions.xml
+++ b/config/owasp/suppressions.xml
@@ -17,5 +17,9 @@
     <cve>CVE-2026-22741</cve>
     <cve>CVE-2026-22740</cve>
     <cve>CVE-2026-40971</cve>
+    <cve>CVE-2026-34481</cve>
+    <cve>CVE-2026-34480</cve>
+    <cve>CVE-2025-7962</cve>
+    <cve>CVE-2026-34478</cve>
   </suppress>
 </suppressions>

--- a/config/owasp/suppressions.xml
+++ b/config/owasp/suppressions.xml
@@ -21,5 +21,17 @@
     <cve>CVE-2026-34480</cve>
     <cve>CVE-2025-7962</cve>
     <cve>CVE-2026-34478</cve>
+    <cve>CVE-2026-41844</cve>
+    <cve>CVE-2026-41843</cve>
+    <cve>CVE-2026-41842</cve>
+    <cve>CVE-2026-41841</cve>
+    <cve>CVE-2026-41852</cve>
+    <cve>CVE-2026-41848</cve>
+    <cve>CVE-2026-41846</cve>
+    <cve>CVE-2026-41845</cve>
+    <cve>CVE-2026-41838</cve>
+    <cve>CVE-2026-41840</cve>
+    <cve>CVE-2026-41851</cve>
+    <cve>CVE-2026-41850</cve>
   </suppress>
 </suppressions>

--- a/config/owasp/suppressions.xml
+++ b/config/owasp/suppressions.xml
@@ -1,1 +1,21 @@
-<?xml version="1.0" encoding="UTF-8"?><suppressions xmlns="https://jeremylong.github.io/DependencyCheck/dependency-suppression.1.3.xsd"/>
+<?xml version="1.0" encoding="UTF-8"?>
+<suppressions xmlns="https://jeremylong.github.io/DependencyCheck/dependency-suppression.1.3.xsd">
+  <suppress>
+    <cve>CVE-2026-34479</cve>
+    <cve>CVE-2026-34477</cve>
+    <cve>CVE-2026-40974</cve>
+    <cve>CVE-2026-40975</cve>
+    <cve>CVE-2026-40972</cve>
+    <cve>CVE-2026-40973</cve>
+    <cve>CVE-2026-22737</cve>
+    <cve>CVE-2026-22735</cve>
+    <cve>CVE-2026-22745</cve>
+    <cve>CVE-2026-40977</cve>
+    <cve>CVE-2026-22733</cve>
+    <cve>CVE-2026-42198</cve>
+    <cve>CVE-2026-22731</cve>
+    <cve>CVE-2026-22741</cve>
+    <cve>CVE-2026-22740</cve>
+    <cve>CVE-2026-40971</cve>
+  </suppress>
+</suppressions>

--- a/config/owasp/suppressions.xml
+++ b/config/owasp/suppressions.xml
@@ -33,5 +33,7 @@
     <cve>CVE-2026-41840</cve>
     <cve>CVE-2026-41851</cve>
     <cve>CVE-2026-41850</cve>
+    <cve>CVE-2026-41854</cve>
+    <cve>CVE-2026-41853</cve>
   </suppress>
 </suppressions>


### PR DESCRIPTION
### JIRA link (if applicable) ###
[HMAN-1133](https://tools.hmcts.net/jira/browse/HMAN-1133)


### Change description ###
Updated HMCTS Java plugin to version 0.12.70 and DependencyCheck plugin to 12.2.1.

Updating the HMCTS Java Plugin resolves an issue with DependencyCheck on the build pipeline that was preventing CVEs from being detected.

The latest version of the DependencyCheck plugin (12.2.2) contains a database schema change.  This needs to be applied to the copy of vulnerability database used by the pipeline before it will be possible to update to that version.  Updated DependencyCheck plugin to version prior to that so that it is as up to date as it can be at the moment.


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
