### PR TITLE
HMAN-1155: Resolve CVEs

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -165,6 +165,7 @@ ext {
   set('log4j2.version', '2.25.4')
   set('snakeyaml.version', '2.3')
   set('commons-lang3.version', '3.18.0')
+  set('jackson.version', '2.18.9')
   reformLogging = '8.0.0'
   lombokVersion = '1.18.38'
   junit = '5.13.4'
@@ -216,7 +217,7 @@ dependencies {
   implementation group: 'net.logstash.logback', name: 'logstash-logback-encoder', version: '8.1'
   implementation group: 'org.projectlombok', name: 'lombok', version: lombokVersion
   annotationProcessor group: 'org.projectlombok', name: 'lombok', version: lombokVersion
-  runtimeOnly group: 'org.postgresql', name: 'postgresql', version: '42.7.11'
+  runtimeOnly group: 'org.postgresql', name: 'postgresql', version: '42.7.12'
 
   testImplementation libraries.junit5
   testImplementation group: 'org.springframework.boot', name: 'spring-boot-starter-test'

--- a/build.gradle
+++ b/build.gradle
@@ -162,7 +162,7 @@ repositories {
 
 ext {
   set('springCloudVersion', '2025.0.0')
-  set('log4j2.version', '2.25.4')
+  set('log4j2.version', '2.25.5')
   set('snakeyaml.version', '2.3')
   set('commons-lang3.version', '3.18.0')
   set('jackson.version', '2.18.9')

--- a/config/owasp/suppressions.xml
+++ b/config/owasp/suppressions.xml
@@ -1,18 +1,15 @@
 <?xml version="1.0" encoding="UTF-8"?><suppressions xmlns="https://jeremylong.github.io/DependencyCheck/dependency-suppression.1.3.xsd">
   <suppress>
-    <notes>Temporary Suppression
-        CVE-2025-7962  False positive, see https://github.com/dependency-check/DependencyCheck/issues/8130
-        CVE-2026-54515 refer [Ticket]
-        CVE-2026-54291 refer [Ticket]
-        CVE-2026-49844 refer [Ticket]</notes>
-    <cve>CVE-2026-54515</cve>
-    <cve>CVE-2026-54291</cve>
-    <cve>CVE-2026-49844</cve>
-  </suppress>
-  <suppress>
+    <notes><![CDATA[
+    The cve.org records for these CVEs indicate that they only apply to httpcore 5.x, but the NVD records state
+    that they apply to all versions up to and including 5.4.2.
+    Discussion at https://github.com/dependency-check/DependencyCheck/issues/8653 suggests NVD need to update their
+    records to exclude versions before 5.x, but there is a suggestion that it could also affect 4.4.16.
+    Apache httpcore 4 is EOL (https://hc.apache.org/httpcomponents-core-4.4.x/index.html) so there may not be any
+    more releases of it.
+    ]]></notes>
+    <packageUrl regex="true">^pkg:maven/org\.apache\.httpcomponents/httpcore@4\.4\.16$</packageUrl>
     <cve>CVE-2026-54399</cve>
-  </suppress>
-  <suppress>
     <cve>CVE-2026-54428</cve>
   </suppress>
 </suppressions>


### PR DESCRIPTION
### JIRA link (if applicable) ###
[HMAN-1155](https://tools.hmcts.net/jira/browse/HMAN-1155)


### Change description ###
Updated log4j.version property to 2.25.5.

Added jackson.version property and set value to 2.18.9.  Unable to use 2.21.x provided by Spring Boot due to limitation caused by befta-fw.

Updated org.postgres:postgresql version to 42.7.12


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
